### PR TITLE
Use `message` key instead of `output` key in `results.json` files

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -51,7 +51,7 @@ else
          | GREP_COLOR='01;31' grep --color=always -E -e '[0-9]+ (error|failure)\(s\)|$' -e '^FAILURE.*$|$' \
          | GREP_COLOR='01;32' grep --color=always -E -e '[0-9]+ success\(es\)|$')
 
-    jq -n --arg output "${test_output}" '{version: 1, status: "fail", output: $output}' > ${results_file}
+    jq -n --arg output "${test_output}" '{version: 1, status: "fail", message: $output}' > ${results_file}
 fi
 
 echo "${slug}: done"

--- a/tests/example-all-fail/expected_results.json
+++ b/tests/example-all-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "raco test: (submod \"/opt/test-runner/tests/example-all-fail/example-all-fail-test.rkt\" test)\n--------------------\nleap tests > vanilla-leap-year\nvanilla-leap-year\nFAILURE\nname:       check-eqv?\nlocation:   example-all-fail-test.rkt:12:5\nactual:     #f\nexpected:   #t\nCheck failure\n--------------------\n--------------------\nleap tests > any-old-year\nany-old-year\nFAILURE\nname:       check-eqv?\nlocation:   example-all-fail-test.rkt:13:5\nactual:     #t\nexpected:   #f\nCheck failure\n--------------------\n0 success(es) 2 failure(s) 0 error(s) 2 test(s) run\n2/2 test failures\n2"
+  "message": "raco test: (submod \"/opt/test-runner/tests/example-all-fail/example-all-fail-test.rkt\" test)\n--------------------\nleap tests > vanilla-leap-year\nvanilla-leap-year\nFAILURE\nname:       check-eqv?\nlocation:   example-all-fail-test.rkt:12:5\nactual:     #f\nexpected:   #t\nCheck failure\n--------------------\n--------------------\nleap tests > any-old-year\nany-old-year\nFAILURE\nname:       check-eqv?\nlocation:   example-all-fail-test.rkt:13:5\nactual:     #t\nexpected:   #f\nCheck failure\n--------------------\n0 success(es) 2 failure(s) 0 error(s) 2 test(s) run\n2/2 test failures\n2"
 }

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "default-load-handler: expected a `module' declaration;\n found end-of-file\n  in: 'example-empty-file\n  context...:\n   standard-module-name-resolver\n   standard-module-name-resolver\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:542:0: test-files73\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:427:0: map/parallel45\n   ...cket/cmdline.rkt:179:51\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt: [running body]\n   /usr/share/racket/collects/raco/raco.rkt: [running body]\n   /usr/share/racket/collects/raco/main.rkt: [running body]"
+  "message": "default-load-handler: expected a `module' declaration;\n found end-of-file\n  in: 'example-empty-file\n  context...:\n   standard-module-name-resolver\n   standard-module-name-resolver\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:542:0: test-files73\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:427:0: map/parallel45\n   ...cket/cmdline.rkt:179:51\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt: [running body]\n   /usr/share/racket/collects/raco/raco.rkt: [running body]\n   /usr/share/racket/collects/raco/main.rkt: [running body]"
 }

--- a/tests/example-partial-fail/expected_results.json
+++ b/tests/example-partial-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "raco test: (submod \"/opt/test-runner/tests/example-partial-fail/example-partial-fail-test.rkt\" test)\n--------------------\nleap tests > exceptional-century\nexceptional-century\nFAILURE\nname:       check-eqv?\nlocation:   example-partial-fail-test.rkt:17:5\nactual:     #f\nexpected:   #t\nCheck failure\n--------------------\n5 success(es) 1 failure(s) 0 error(s) 6 test(s) run\n1/6 test failures\n1"
+  "message": "raco test: (submod \"/opt/test-runner/tests/example-partial-fail/example-partial-fail-test.rkt\" test)\n--------------------\nleap tests > exceptional-century\nexceptional-century\nFAILURE\nname:       check-eqv?\nlocation:   example-partial-fail-test.rkt:17:5\nactual:     #f\nexpected:   #t\nCheck failure\n--------------------\n5 success(es) 1 failure(s) 0 error(s) 6 test(s) run\n1/6 test failures\n1"
 }

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "example-syntax-error.rkt:3:26: read: unexpected `)'\n  context...:\n   /usr/share/racket/collects/syntax/module-reader.rkt:185:17: body\n   /usr/share/racket/collects/syntax/module-reader.rkt:182:2: wrap-internal\n   /usr/share/racket/collects/racket/../syntax/module-reader.rkt:64:9: lang:read-syntax\n   standard-module-name-resolver"
+  "message": "example-syntax-error.rkt:3:26: read: unexpected `)'\n  context...:\n   /usr/share/racket/collects/syntax/module-reader.rkt:185:17: body\n   /usr/share/racket/collects/syntax/module-reader.rkt:182:2: wrap-internal\n   /usr/share/racket/collects/racket/../syntax/module-reader.rkt:64:9: lang:read-syntax\n   standard-module-name-resolver"
 }


### PR DESCRIPTION
This PR fixes an invalid implementation of the test runner v1 spec, where the `message` key was used instead of the `output` key in the `results.json` files

## Tracking

https://github.com/exercism/v3-launch/issues/38