### PR TITLE
Upgrade to Racket 8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM racket/racket:6.6-full
+FROM racket/racket:8.2-full
 
 RUN apt-get update && \
     apt-get install -y jq && \

--- a/tests/example-all-fail/expected_results.json
+++ b/tests/example-all-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "message": "raco test: (submod \"/opt/test-runner/tests/example-all-fail/example-all-fail-test.rkt\" test)\n--------------------\nleap tests > vanilla-leap-year\nvanilla-leap-year\nFAILURE\nname:       check-eqv?\nlocation:   example-all-fail-test.rkt:12:5\nactual:     #f\nexpected:   #t\nCheck failure\n--------------------\n--------------------\nleap tests > any-old-year\nany-old-year\nFAILURE\nname:       check-eqv?\nlocation:   example-all-fail-test.rkt:13:5\nactual:     #t\nexpected:   #f\nCheck failure\n--------------------\n0 success(es) 2 failure(s) 0 error(s) 2 test(s) run\n2/2 test failures\n2"
+  "message": "raco test: (submod \"/opt/test-runner/tests/example-all-fail/example-all-fail-test.rkt\" test)\n--------------------\nleap tests > vanilla-leap-year\nFAILURE\nname:       check-eqv?\nlocation:   example-all-fail-test.rkt:12:5\nactual:     #f\nexpected:   #t\n--------------------\n--------------------\nleap tests > any-old-year\nFAILURE\nname:       check-eqv?\nlocation:   example-all-fail-test.rkt:13:5\nactual:     #t\nexpected:   #f\n--------------------\n0 success(es) 2 failure(s) 0 error(s) 2 test(s) run\n2/2 test failures\n2"
 }

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "message": "default-load-handler: expected a `module' declaration;\n found end-of-file\n  in: 'example-empty-file\n  context...:\n   standard-module-name-resolver\n   standard-module-name-resolver\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:542:0: test-files73\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:427:0: map/parallel45\n   ...cket/cmdline.rkt:179:51\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt: [running body]\n   /usr/share/racket/collects/raco/raco.rkt: [running body]\n   /usr/share/racket/collects/raco/main.rkt: [running body]"
+  "message": "default-load-handler: expected a `module' declaration;\n found end-of-file\n  in: #<path:/opt/test-runner/tests/example-empty-file/example-empty-file.rkt>\n  context...:\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:383:27\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:385:0: call-with-summary\n   .../private/map.rkt:40:19: loop\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:1113:1: test\n   body of \"/usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt\"\n   /usr/share/racket/collects/raco/raco.rkt:41:0\n   body of \"/usr/share/racket/collects/raco/raco.rkt\"\n   body of \"/usr/share/racket/collects/raco/main.rkt\""
 }

--- a/tests/example-partial-fail/expected_results.json
+++ b/tests/example-partial-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "message": "raco test: (submod \"/opt/test-runner/tests/example-partial-fail/example-partial-fail-test.rkt\" test)\n--------------------\nleap tests > exceptional-century\nexceptional-century\nFAILURE\nname:       check-eqv?\nlocation:   example-partial-fail-test.rkt:17:5\nactual:     #f\nexpected:   #t\nCheck failure\n--------------------\n5 success(es) 1 failure(s) 0 error(s) 6 test(s) run\n1/6 test failures\n1"
+  "message": "raco test: (submod \"/opt/test-runner/tests/example-partial-fail/example-partial-fail-test.rkt\" test)\n--------------------\nleap tests > exceptional-century\nFAILURE\nname:       check-eqv?\nlocation:   example-partial-fail-test.rkt:17:5\nactual:     #f\nexpected:   #t\n--------------------\n5 success(es) 1 failure(s) 0 error(s) 6 test(s) run\n1/6 test failures\n1"
 }

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "message": "example-syntax-error.rkt:3:26: read: unexpected `)'\n  context...:\n   /usr/share/racket/collects/syntax/module-reader.rkt:185:17: body\n   /usr/share/racket/collects/syntax/module-reader.rkt:182:2: wrap-internal\n   /usr/share/racket/collects/racket/../syntax/module-reader.rkt:64:9: lang:read-syntax\n   standard-module-name-resolver"
+  "message": "example-syntax-error.rkt:3:26: read-syntax: unexpected `)`\n  context...:\n   /usr/share/racket/collects/syntax/module-reader.rkt:186:17: body\n   /usr/share/racket/collects/syntax/module-reader.rkt:183:2: wrap-internal\n   /usr/share/racket/collects/racket/../syntax/module-reader.rkt:67:9: wrap-internal/wrapper\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:383:27\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:385:0: call-with-summary\n   .../private/map.rkt:40:19: loop\n   /usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt:1113:1: test\n   body of \"/usr/share/racket/pkgs/compiler-lib/compiler/commands/test.rkt\"\n   /usr/share/racket/collects/raco/raco.rkt:41:0\n   body of \"/usr/share/racket/collects/raco/raco.rkt\"\n   body of \"/usr/share/racket/collects/raco/main.rkt\""
 }


### PR DESCRIPTION
Closes https://github.com/exercism/racket-test-runner/issues/28

This fixes the issue mentioned in #28 where a certain solution was very slow.

Racket 6.6:

```
real    0m33.879s
user    0m0.169s
sys     0m0.115s
````


Racket 8.2:

```
real    0m5.405s
user    0m0.183s
sys     0m0.091s
```