### PR TITLE
Upgrade Racket to 8.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM racket/racket:8.11
+FROM racket/racket:8.12
 
 RUN apt-get install -y jq
 RUN raco pkg install zo-lib testing-util-lib rackunit-lib scheme-lib compiler-lib


### PR DESCRIPTION
Racket 8.12 dropped three days ago per https://blog.racket-lang.org/2024/02/racket-v8-12.html.  `/bin/run-tests-in-docker.sh` shows all tests passing with no need to update the expected results.