### PR TITLE
Update to 8.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM racket/racket:8.14
+FROM racket/racket:8.15
 
 RUN apt-get install -y jq
 RUN raco pkg install zo-lib testing-util-lib rackunit-lib scheme-lib compiler-lib


### PR DESCRIPTION
8.15 dropped yesterday, and I have an open PR to update the official Racket Docker image. Once that's in, we can update the test runner. The testing CI was already updated on the main track repo.